### PR TITLE
Improve code review skill

### DIFF
--- a/packages/claude-tandem/skills/code-review/SKILL.md
+++ b/packages/claude-tandem/skills/code-review/SKILL.md
@@ -3,19 +3,13 @@ name: code-review
 description: Use when asked to do a code review.
 ---
 
-Read the full diff and everything it touches before judging; the worst review
-mistakes come from reviewing the diff only.
+Read the full diff and everything it touches before judging; the worst review mistakes come from reviewing the diff only. The review is read-only: never modify tracked files, the index, HEAD, or branch state; running builds and tests to verify the change is fine.
+
+Review as a lazy senior engineer: besides bugs, flag NIH syndrome, overengineering, unnecessary dependencies, obvious copy paste and other similar code bloats. Give accompanying tests the same, if not higher, level of attention: unreadable, overcomplicated tests explain nothing, and a test that would also pass without the change proves nothing.
 
 Report rules:
 
-- Actionable findings only, ordered by severity: ones requiring changes, or
-  at least explicit decisions; "checked and fine" does not qualify.
-- Each finding: what is wrong and why it matters in 1-3 lines, then the
-  smallest fix - as a diff if it fits within 50 LoC, otherwise described
-  generally, asking for a decision.
-- No praise, no diff summary, no restating the request, no advice beyond
-  findings.
+- Actionable findings only, ordered by severity: ones requiring changes, or at least explicit decisions; "checked and fine" does not qualify.
+- Each finding: what is wrong and why it matters in 1-3 lines, then the smallest fix as a concrete diff, or set of diffs; if not diffable, describe generally and ask for a decision.
+- No praise, no diff summary, no restating the request, no advice beyond findings.
 - If nothing actionable: say exactly that, plus one line on what was checked.
-- Before writing, verify: grep for references to removed or renamed
-  identifiers; where the repo has rendered build output, check it is in sync;
-  diff the commit message claims against the actual change.

--- a/packages/pi-tandem/skills/code-review/SKILL.md
+++ b/packages/pi-tandem/skills/code-review/SKILL.md
@@ -3,19 +3,13 @@ name: code-review
 description: Use when asked to do a code review.
 ---
 
-Read the full diff and everything it touches before judging; the worst review
-mistakes come from reviewing the diff only.
+Read the full diff and everything it touches before judging; the worst review mistakes come from reviewing the diff only. The review is read-only: never modify tracked files, the index, HEAD, or branch state; running builds and tests to verify the change is fine.
+
+Review as a lazy senior engineer: besides bugs, flag NIH syndrome, overengineering, unnecessary dependencies, obvious copy paste and other similar code bloats. Give accompanying tests the same, if not higher, level of attention: unreadable, overcomplicated tests explain nothing, and a test that would also pass without the change proves nothing.
 
 Report rules:
 
-- Actionable findings only, ordered by severity: ones requiring changes, or
-  at least explicit decisions; "checked and fine" does not qualify.
-- Each finding: what is wrong and why it matters in 1-3 lines, then the
-  smallest fix - as a diff if it fits within 50 LoC, otherwise described
-  generally, asking for a decision.
-- No praise, no diff summary, no restating the request, no advice beyond
-  findings.
+- Actionable findings only, ordered by severity: ones requiring changes, or at least explicit decisions; "checked and fine" does not qualify.
+- Each finding: what is wrong and why it matters in 1-3 lines, then the smallest fix as a concrete diff, or set of diffs; if not diffable, describe generally and ask for a decision.
+- No praise, no diff summary, no restating the request, no advice beyond findings.
 - If nothing actionable: say exactly that, plus one line on what was checked.
-- Before writing, verify: grep for references to removed or renamed
-  identifiers; where the repo has rendered build output, check it is in sync;
-  diff the commit message claims against the actual change.

--- a/src/skills/code-review/SKILL.md
+++ b/src/skills/code-review/SKILL.md
@@ -3,19 +3,13 @@ name: code-review
 description: Use when asked to do a code review.
 ---
 
-Read the full diff and everything it touches before judging; the worst review
-mistakes come from reviewing the diff only.
+Read the full diff and everything it touches before judging; the worst review mistakes come from reviewing the diff only. The review is read-only: never modify tracked files, the index, HEAD, or branch state; running builds and tests to verify the change is fine.
+
+Review as a lazy senior engineer: besides bugs, flag NIH syndrome, overengineering, unnecessary dependencies, obvious copy paste and other similar code bloats. Give accompanying tests the same, if not higher, level of attention: unreadable, overcomplicated tests explain nothing, and a test that would also pass without the change proves nothing.
 
 Report rules:
 
-- Actionable findings only, ordered by severity: ones requiring changes, or
-  at least explicit decisions; "checked and fine" does not qualify.
-- Each finding: what is wrong and why it matters in 1-3 lines, then the
-  smallest fix - as a diff if it fits within 50 LoC, otherwise described
-  generally, asking for a decision.
-- No praise, no diff summary, no restating the request, no advice beyond
-  findings.
+- Actionable findings only, ordered by severity: ones requiring changes, or at least explicit decisions; "checked and fine" does not qualify.
+- Each finding: what is wrong and why it matters in 1-3 lines, then the smallest fix as a concrete diff, or set of diffs; if not diffable, describe generally and ask for a decision.
+- No praise, no diff summary, no restating the request, no advice beyond findings.
 - If nothing actionable: say exactly that, plus one line on what was checked.
-- Before writing, verify: grep for references to removed or renamed
-  identifiers; where the repo has rendered build output, check it is in sync;
-  diff the commit message claims against the actual change.


### PR DESCRIPTION
Tighten the code-review skill prompt:

- Reviews are read-only; running builds/tests to verify is fine
- Review with a lazy-senior mindset: flag NIH, overengineering, unnecessary deps, copy-paste bloat
- Bad tests called out explicitly: overcomplicated or ones that pass without the change
- Findings come as concrete diffs, no 50 LoC cap