### PR TITLE
Recommend html2text for reading web pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as text instead of raw markup
+- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as markdown instead of raw markup
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -24,7 +24,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as text instead of raw markup
+- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as markdown instead of raw markup
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/packages/claude-tandem/prompt.md
+++ b/packages/claude-tandem/prompt.md
@@ -53,8 +53,8 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pdftotext` to extract text from PDFs: `pdftotext input.pdf output.txt`, or `pdftotext input.pdf -` to print to stdout
 <!--/cli-->
 <!--cli:pandoc-->
-- Use `pandoc` to read documents other than pdf as markdown or plain text: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-- Unless your task requires seeing actual tags, always convert HTML fetched from the web to plain text or markdown, instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t plain`.
+- Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t gfm`.
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -23,7 +23,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as text instead of raw markup
+- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as markdown instead of raw markup
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/packages/pi-tandem/prompt.md
+++ b/packages/pi-tandem/prompt.md
@@ -47,8 +47,8 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pdftotext` to extract text from PDFs: `pdftotext input.pdf output.txt`, or `pdftotext input.pdf -` to print to stdout
 <!--/cli-->
 <!--cli:pandoc-->
-- Use `pandoc` to read documents other than pdf as markdown or plain text: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-- Unless your task requires seeing actual tags, always convert HTML fetched from the web to plain text or markdown, instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t plain`.
+- Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t gfm`.
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`

--- a/src/README.md
+++ b/src/README.md
@@ -21,7 +21,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as text instead of raw markup
+- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as markdown instead of raw markup
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -47,8 +47,8 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pdftotext` to extract text from PDFs: `pdftotext input.pdf output.txt`, or `pdftotext input.pdf -` to print to stdout
 <!--/cli-->
 <!--cli:pandoc-->
-- Use `pandoc` to read documents other than pdf as markdown or plain text: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-- Unless your task requires seeing actual tags, always convert HTML fetched from the web to plain text or markdown, instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t plain`.
+- Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t gfm`.
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`


### PR DESCRIPTION
Replaces the pandoc-HTML recommendation with the Python html2text (`pipx install html2text`): converts pages to markdown, keeps links inline, strips images/base64 noise. Tested on paseo.sh, HN, Wikipedia, python docs.