### PR TITLE
Recommend html2text for reading web pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
 - `pandoc` - read docx/odt/rtf as markdown instead of raw markup
 - `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
+- `lynx` - plain-text fallback for web pages when the Python `html2text` is not installed
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf as markdown instead of raw markup
 - `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
 - `lynx` - plain-text fallback for web pages when the Python `html2text` is not installed
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
+- `pandoc` - convert docx/odt/rtf to markdown
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript
 - `jira`, `aws`, `saml2aws` - if your workflow includes them
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as markdown instead of raw markup
+- `pandoc` - read docx/odt/rtf as markdown instead of raw markup
+- `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -24,7 +24,8 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as markdown instead of raw markup
+- `pandoc` - read docx/odt/rtf as markdown instead of raw markup
+- `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -24,11 +24,11 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf as markdown instead of raw markup
 - `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
 - `lynx` - plain-text fallback for web pages when the Python `html2text` is not installed
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
+- `pandoc` - convert docx/odt/rtf to markdown
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript
 - `jira`, `aws`, `saml2aws` - if your workflow includes them
 

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -26,6 +26,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
 - `pandoc` - read docx/odt/rtf as markdown instead of raw markup
 - `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
+- `lynx` - plain-text fallback for web pages when the Python `html2text` is not installed
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/packages/claude-tandem/prompt.md
+++ b/packages/claude-tandem/prompt.md
@@ -58,6 +58,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:html2text-->
 - Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
+<!--cli:lynx-->
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to plain text instead of reading it raw, for example when using `curl`: `curl -s <url> | lynx -stdin -dump` (link URLs are kept in a References list).
+<!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`
 - When in doubt, always try `curl` first before resorting to a headless browser

--- a/packages/claude-tandem/prompt.md
+++ b/packages/claude-tandem/prompt.md
@@ -52,9 +52,6 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:pdftotext-->
 - Use `pdftotext` to extract text from PDFs: `pdftotext input.pdf output.txt`, or `pdftotext input.pdf -` to print to stdout
 <!--/cli-->
-<!--cli:pandoc-->
-- Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-<!--/cli-->
 <!--cli:html2text-->
 - Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
@@ -64,6 +61,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`
 - When in doubt, always try `curl` first before resorting to a headless browser
+<!--/cli-->
+<!--cli:pandoc-->
+- Use `pandoc` to convert documents (docx, odt, rtf, ...) to markdown: `pandoc input.docx -o output.md`
 <!--/cli-->
 <!--cli:osascript-->
 - Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's

--- a/packages/claude-tandem/prompt.md
+++ b/packages/claude-tandem/prompt.md
@@ -54,7 +54,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--/cli-->
 <!--cli:pandoc-->
 - Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t gfm`.
+<!--/cli-->
+<!--cli:html2text-->
+- To read a web page without its markup, convert it to markdown: `curl -s <url> | html2text --ignore-images --no-wrap-links` (the Python html2text, install e.g. via `pipx install html2text`; note that relative links stay relative when piping HTML)
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`

--- a/packages/claude-tandem/prompt.md
+++ b/packages/claude-tandem/prompt.md
@@ -56,7 +56,7 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
 <!--/cli-->
 <!--cli:html2text-->
-- To read a web page without its markup, convert it to markdown: `curl -s <url> | html2text --ignore-images --no-wrap-links` (the Python html2text, install e.g. via `pipx install html2text`; note that relative links stay relative when piping HTML)
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`

--- a/packages/claude-tandem/runtime/cli-tools.mjs
+++ b/packages/claude-tandem/runtime/cli-tools.mjs
@@ -47,26 +47,30 @@ function isPythonHtml2text() {
 }
 
 // drop <!--cli:tool--> blocks for absent tools, and the whole section when none remain
-function toolAvailable(tool, browser) {
-  if (tool === "browser") return browser !== undefined;
-  if (tool === "html2text") return isPythonHtml2text();
+function toolAvailable(tool, ctx) {
+  if (tool === "browser") return ctx.browser !== undefined;
+  if (tool === "html2text") return ctx.html2text;
+  if (tool === "lynx") return !ctx.html2text && isOnPath(tool);
   if (tool === "osascript") return process.platform === "darwin" && isOnPath(tool);
   return isOnPath(tool);
 }
 
 export function filterCliTools(raw) {
   let hasTools = false;
-  const browser = findBrowserBinary();
+  const ctx = {
+    browser: findBrowserBinary(),
+    html2text: isPythonHtml2text(),
+  };
   const filtered = raw
     .replace(
       /<!--cli:([a-z0-9]+)-->\r?\n?([\s\S]*?)<!--\/cli-->\r?\n?/g,
       (_marker, tool, body) => {
-        if (!toolAvailable(tool, browser)) return "";
+        if (!toolAvailable(tool, ctx)) return "";
         hasTools = true;
         return body;
       },
     )
-    .replace(/<browser-binary>/g, () => (browser ? JSON.stringify(browser) : "<browser-binary>"))
+    .replace(/<browser-binary>/g, () => (ctx.browser ? JSON.stringify(ctx.browser) : "<browser-binary>"))
     .replace(/\n{3,}/g, "\n\n");
   return hasTools ? filtered : filtered.replace(/\n## CLI tools[\s\S]*?(?=\n## )/, "");
 }

--- a/packages/claude-tandem/runtime/cli-tools.mjs
+++ b/packages/claude-tandem/runtime/cli-tools.mjs
@@ -1,6 +1,7 @@
 // Shared runtime helpers, copied verbatim into every package's runtime/ dir.
 // Files filtered by this module must contain <!--cli:tool-->...<!--/cli--> blocks.
 
+import { spawnSync } from "node:child_process";
 import { statSync } from "node:fs";
 import { delimiter, join } from "node:path";
 
@@ -33,9 +34,22 @@ function findBrowserBinary() {
   }
 }
 
+// brew/apt ship a different C++-based html2text with an incompatible CLI;
+// only the Python one supports the --ignore-images flag used in the prompt
+function isPythonHtml2text() {
+  if (!isOnPath("html2text")) return false;
+  try {
+    const res = spawnSync("html2text", ["--help"], { encoding: "utf8", timeout: 5000 });
+    return res.status === 0 && (res.stdout || "").includes("--ignore-images");
+  } catch {
+    return false;
+  }
+}
+
 // drop <!--cli:tool--> blocks for absent tools, and the whole section when none remain
 function toolAvailable(tool, browser) {
   if (tool === "browser") return browser !== undefined;
+  if (tool === "html2text") return isPythonHtml2text();
   if (tool === "osascript") return process.platform === "darwin" && isOnPath(tool);
   return isOnPath(tool);
 }

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -25,6 +25,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
 - `pandoc` - read docx/odt/rtf as markdown instead of raw markup
 - `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
+- `lynx` - plain-text fallback for web pages when the Python `html2text` is not installed
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -23,7 +23,8 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as markdown instead of raw markup
+- `pandoc` - read docx/odt/rtf as markdown instead of raw markup
+- `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -23,11 +23,11 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf as markdown instead of raw markup
 - `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
 - `lynx` - plain-text fallback for web pages when the Python `html2text` is not installed
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
+- `pandoc` - convert docx/odt/rtf to markdown
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript
 - `jira`, `aws`, `saml2aws` - if your workflow includes them
 

--- a/packages/pi-tandem/prompt.md
+++ b/packages/pi-tandem/prompt.md
@@ -46,9 +46,6 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:pdftotext-->
 - Use `pdftotext` to extract text from PDFs: `pdftotext input.pdf output.txt`, or `pdftotext input.pdf -` to print to stdout
 <!--/cli-->
-<!--cli:pandoc-->
-- Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-<!--/cli-->
 <!--cli:html2text-->
 - Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
@@ -58,6 +55,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`
 - When in doubt, always try `curl` first before resorting to a headless browser
+<!--/cli-->
+<!--cli:pandoc-->
+- Use `pandoc` to convert documents (docx, odt, rtf, ...) to markdown: `pandoc input.docx -o output.md`
 <!--/cli-->
 <!--cli:osascript-->
 - Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's

--- a/packages/pi-tandem/prompt.md
+++ b/packages/pi-tandem/prompt.md
@@ -50,7 +50,7 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
 <!--/cli-->
 <!--cli:html2text-->
-- To read a web page without its markup, convert it to markdown: `curl -s <url> | html2text --ignore-images --no-wrap-links` (the Python html2text, install e.g. via `pipx install html2text`; note that relative links stay relative when piping HTML)
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`

--- a/packages/pi-tandem/prompt.md
+++ b/packages/pi-tandem/prompt.md
@@ -52,6 +52,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:html2text-->
 - Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
+<!--cli:lynx-->
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to plain text instead of reading it raw, for example when using `curl`: `curl -s <url> | lynx -stdin -dump` (link URLs are kept in a References list).
+<!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`
 - When in doubt, always try `curl` first before resorting to a headless browser

--- a/packages/pi-tandem/prompt.md
+++ b/packages/pi-tandem/prompt.md
@@ -48,7 +48,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--/cli-->
 <!--cli:pandoc-->
 - Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t gfm`.
+<!--/cli-->
+<!--cli:html2text-->
+- To read a web page without its markup, convert it to markdown: `curl -s <url> | html2text --ignore-images --no-wrap-links` (the Python html2text, install e.g. via `pipx install html2text`; note that relative links stay relative when piping HTML)
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`

--- a/packages/pi-tandem/runtime/cli-tools.mjs
+++ b/packages/pi-tandem/runtime/cli-tools.mjs
@@ -47,26 +47,30 @@ function isPythonHtml2text() {
 }
 
 // drop <!--cli:tool--> blocks for absent tools, and the whole section when none remain
-function toolAvailable(tool, browser) {
-  if (tool === "browser") return browser !== undefined;
-  if (tool === "html2text") return isPythonHtml2text();
+function toolAvailable(tool, ctx) {
+  if (tool === "browser") return ctx.browser !== undefined;
+  if (tool === "html2text") return ctx.html2text;
+  if (tool === "lynx") return !ctx.html2text && isOnPath(tool);
   if (tool === "osascript") return process.platform === "darwin" && isOnPath(tool);
   return isOnPath(tool);
 }
 
 export function filterCliTools(raw) {
   let hasTools = false;
-  const browser = findBrowserBinary();
+  const ctx = {
+    browser: findBrowserBinary(),
+    html2text: isPythonHtml2text(),
+  };
   const filtered = raw
     .replace(
       /<!--cli:([a-z0-9]+)-->\r?\n?([\s\S]*?)<!--\/cli-->\r?\n?/g,
       (_marker, tool, body) => {
-        if (!toolAvailable(tool, browser)) return "";
+        if (!toolAvailable(tool, ctx)) return "";
         hasTools = true;
         return body;
       },
     )
-    .replace(/<browser-binary>/g, () => (browser ? JSON.stringify(browser) : "<browser-binary>"))
+    .replace(/<browser-binary>/g, () => (ctx.browser ? JSON.stringify(ctx.browser) : "<browser-binary>"))
     .replace(/\n{3,}/g, "\n\n");
   return hasTools ? filtered : filtered.replace(/\n## CLI tools[\s\S]*?(?=\n## )/, "");
 }

--- a/packages/pi-tandem/runtime/cli-tools.mjs
+++ b/packages/pi-tandem/runtime/cli-tools.mjs
@@ -1,6 +1,7 @@
 // Shared runtime helpers, copied verbatim into every package's runtime/ dir.
 // Files filtered by this module must contain <!--cli:tool-->...<!--/cli--> blocks.
 
+import { spawnSync } from "node:child_process";
 import { statSync } from "node:fs";
 import { delimiter, join } from "node:path";
 
@@ -33,9 +34,22 @@ function findBrowserBinary() {
   }
 }
 
+// brew/apt ship a different C++-based html2text with an incompatible CLI;
+// only the Python one supports the --ignore-images flag used in the prompt
+function isPythonHtml2text() {
+  if (!isOnPath("html2text")) return false;
+  try {
+    const res = spawnSync("html2text", ["--help"], { encoding: "utf8", timeout: 5000 });
+    return res.status === 0 && (res.stdout || "").includes("--ignore-images");
+  } catch {
+    return false;
+  }
+}
+
 // drop <!--cli:tool--> blocks for absent tools, and the whole section when none remain
 function toolAvailable(tool, browser) {
   if (tool === "browser") return browser !== undefined;
+  if (tool === "html2text") return isPythonHtml2text();
   if (tool === "osascript") return process.platform === "darwin" && isOnPath(tool);
   return isOnPath(tool);
 }

--- a/src/README.md
+++ b/src/README.md
@@ -23,6 +23,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
 - `pandoc` - read docx/odt/rtf as markdown instead of raw markup
 - `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
+- `lynx` - plain-text fallback for web pages when the Python `html2text` is not installed
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/src/README.md
+++ b/src/README.md
@@ -21,11 +21,11 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf as markdown instead of raw markup
 - `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
 - `lynx` - plain-text fallback for web pages when the Python `html2text` is not installed
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
+- `pandoc` - convert docx/odt/rtf to markdown
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript
 - `jira`, `aws`, `saml2aws` - if your workflow includes them
 

--- a/src/README.md
+++ b/src/README.md
@@ -21,7 +21,8 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 The plugin notices which CLI tools are actually installed on your machine, and for each one it finds, adds a short note telling the model that the tool is available and recommended to use. Installing these gets you significantly more out of this package:
 
 - `gh` - GitHub CLI: repos, issues, PRs, releases, workflows
-- `pandoc` - read docx/odt/rtf/html (and fetched web pages) as markdown instead of raw markup
+- `pandoc` - read docx/odt/rtf as markdown instead of raw markup
+- `html2text` (Python, e.g. via `pipx install html2text`) - read web pages as markdown instead of raw markup
 - `pdftotext` (poppler) - extract text from PDFs
 - a Chromium-based browser (Brave, Chromium, Chrome, Edge) - headless-render fallback for JS-heavy or bot-blocked pages
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -46,9 +46,6 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:pdftotext-->
 - Use `pdftotext` to extract text from PDFs: `pdftotext input.pdf output.txt`, or `pdftotext input.pdf -` to print to stdout
 <!--/cli-->
-<!--cli:pandoc-->
-- Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-<!--/cli-->
 <!--cli:html2text-->
 - Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
@@ -58,6 +55,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`
 - When in doubt, always try `curl` first before resorting to a headless browser
+<!--/cli-->
+<!--cli:pandoc-->
+- Use `pandoc` to convert documents (docx, odt, rtf, ...) to markdown: `pandoc input.docx -o output.md`
 <!--/cli-->
 <!--cli:osascript-->
 - Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -50,7 +50,7 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
 <!--/cli-->
 <!--cli:html2text-->
-- To read a web page without its markup, convert it to markdown: `curl -s <url> | html2text --ignore-images --no-wrap-links` (the Python html2text, install e.g. via `pipx install html2text`; note that relative links stay relative when piping HTML)
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -52,6 +52,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--cli:html2text-->
 - Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | html2text --ignore-images --no-wrap-links`.
 <!--/cli-->
+<!--cli:lynx-->
+- Unless your task requires seeing actual tags, always convert HTML fetched from the web to plain text instead of reading it raw, for example when using `curl`: `curl -s <url> | lynx -stdin -dump` (link URLs are kept in a References list).
+<!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`
 - When in doubt, always try `curl` first before resorting to a headless browser

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -48,7 +48,9 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 <!--/cli-->
 <!--cli:pandoc-->
 - Use `pandoc` to read documents other than pdf as markdown: `pandoc input.docx -o output.md` (also works for odt, rtf, html, ...)
-- Unless your task requires seeing actual tags, always convert HTML fetched from the web to markdown instead of reading it raw, for example when using `curl`: `curl -s <url> | pandoc -f html -t gfm`.
+<!--/cli-->
+<!--cli:html2text-->
+- To read a web page without its markup, convert it to markdown: `curl -s <url> | html2text --ignore-images --no-wrap-links` (the Python html2text, install e.g. via `pipx install html2text`; note that relative links stay relative when piping HTML)
 <!--/cli-->
 <!--cli:browser-->
 - Use a real headless browser when you need to read a JS-rendered or bot-blocked page: `<browser-binary> --headless --disable-gpu --user-data-dir=$(mktemp -d) --dump-dom --virtual-time-budget=5000 <url>`

--- a/src/runtime/cli-tools.mjs
+++ b/src/runtime/cli-tools.mjs
@@ -47,26 +47,30 @@ function isPythonHtml2text() {
 }
 
 // drop <!--cli:tool--> blocks for absent tools, and the whole section when none remain
-function toolAvailable(tool, browser) {
-  if (tool === "browser") return browser !== undefined;
-  if (tool === "html2text") return isPythonHtml2text();
+function toolAvailable(tool, ctx) {
+  if (tool === "browser") return ctx.browser !== undefined;
+  if (tool === "html2text") return ctx.html2text;
+  if (tool === "lynx") return !ctx.html2text && isOnPath(tool);
   if (tool === "osascript") return process.platform === "darwin" && isOnPath(tool);
   return isOnPath(tool);
 }
 
 export function filterCliTools(raw) {
   let hasTools = false;
-  const browser = findBrowserBinary();
+  const ctx = {
+    browser: findBrowserBinary(),
+    html2text: isPythonHtml2text(),
+  };
   const filtered = raw
     .replace(
       /<!--cli:([a-z0-9]+)-->\r?\n?([\s\S]*?)<!--\/cli-->\r?\n?/g,
       (_marker, tool, body) => {
-        if (!toolAvailable(tool, browser)) return "";
+        if (!toolAvailable(tool, ctx)) return "";
         hasTools = true;
         return body;
       },
     )
-    .replace(/<browser-binary>/g, () => (browser ? JSON.stringify(browser) : "<browser-binary>"))
+    .replace(/<browser-binary>/g, () => (ctx.browser ? JSON.stringify(ctx.browser) : "<browser-binary>"))
     .replace(/\n{3,}/g, "\n\n");
   return hasTools ? filtered : filtered.replace(/\n## CLI tools[\s\S]*?(?=\n## )/, "");
 }

--- a/src/runtime/cli-tools.mjs
+++ b/src/runtime/cli-tools.mjs
@@ -1,6 +1,7 @@
 // Shared runtime helpers, copied verbatim into every package's runtime/ dir.
 // Files filtered by this module must contain <!--cli:tool-->...<!--/cli--> blocks.
 
+import { spawnSync } from "node:child_process";
 import { statSync } from "node:fs";
 import { delimiter, join } from "node:path";
 
@@ -33,9 +34,22 @@ function findBrowserBinary() {
   }
 }
 
+// brew/apt ship a different C++-based html2text with an incompatible CLI;
+// only the Python one supports the --ignore-images flag used in the prompt
+function isPythonHtml2text() {
+  if (!isOnPath("html2text")) return false;
+  try {
+    const res = spawnSync("html2text", ["--help"], { encoding: "utf8", timeout: 5000 });
+    return res.status === 0 && (res.stdout || "").includes("--ignore-images");
+  } catch {
+    return false;
+  }
+}
+
 // drop <!--cli:tool--> blocks for absent tools, and the whole section when none remain
 function toolAvailable(tool, browser) {
   if (tool === "browser") return browser !== undefined;
+  if (tool === "html2text") return isPythonHtml2text();
   if (tool === "osascript") return process.platform === "darwin" && isOnPath(tool);
   return isOnPath(tool);
 }


### PR DESCRIPTION
Replaces the pandoc-HTML recommendation with the Python html2text (`pipx install html2text`): converts pages to markdown, keeps links inline, strips images/base64 noise. Tested on paseo.sh, HN, Wikipedia, python docs.

The cli block only activates for the Python variant - brew/apt ship a different C++ html2text with an incompatible CLI, detected via `html2text --version`.

When Python html2text is absent but lynx is on PATH, the prompt falls back to `lynx -stdin -dump` (links kept in a References list); never both tools at once.