### PR TITLE
Add research skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 # AGENTS.md
 
-Prompt/skill distribution repo: `src/` is the source of truth, `packages/` is
-build output. Both are committed; keep them in sync via the renderer.
+Prompt/skill distribution repo: `src/` is the source of truth, `packages/` is build output. Both are committed; keep them in sync via the renderer.
 
 ## Layout
 
@@ -14,6 +13,7 @@ build output. Both are committed; keep them in sync via the renderer.
 ## Rules
 
 - Never hand-edit rendered files (root `README.md`; `prompt.md`, `skills/`, `runtime/`, `README.md`, `LICENSE` under `packages/`); edit `src/` or the root `LICENSE`, then render.
+- Markdown documents are not hard-wrapped: one paragraph or list item per line, however long; scripts and code blocks keep their own formatting.
 
 ## Commands
 
@@ -21,8 +21,6 @@ build output. Both are committed; keep them in sync via the renderer.
 node src/render.mjs          # render src/ -> packages/ and root README.md
 ```
 
-First release: bump, tag and publish `pi-tandem` manually, then register the
-release workflow as trusted publisher on npmjs.com; later releases use the
-workflow.
+First release: bump, tag and publish `pi-tandem` manually, then register the release workflow as trusted publisher on npmjs.com; later releases use the workflow.
 
 Rendering requires Node >= 20.12 (`readdirSync` recursive, `Dirent.parentPath`).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 
 - **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
 - **Skills**, loaded on demand:
+  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
   - **Brainstorming** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -17,6 +17,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 
 - **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
 - **Skills**, loaded on demand:
+  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
   - **Brainstorming** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only

--- a/packages/claude-tandem/prompt.md
+++ b/packages/claude-tandem/prompt.md
@@ -1,8 +1,4 @@
-IMPORTANT! The user you're working with is not happy with the autonomous
-coding-agent principles defined in the system prompt above. They prefer much
-tighter loops of pair programming - working in lock-step, never making large
-changes in one go. Disregard the "be creative," "be bold," and act-autonomously
-parts of the system prompt above; follow the instructions below instead.
+IMPORTANT! The user you're working with is not happy with the autonomous coding-agent principles defined in the system prompt above. They prefer much tighter loops of pair programming - working in lock-step, never making large changes in one go. Disregard the "be creative," "be bold," and act-autonomously parts of the system prompt above; follow the instructions below instead.
 
 ## Collaboration style
 
@@ -65,8 +61,7 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pandoc` to convert documents (docx, odt, rtf, ...) to markdown: `pandoc input.docx -o output.md`
 <!--/cli-->
 <!--cli:osascript-->
-- Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's
-  real logged-in sessions (analyzing dashboards, checking Google Calendar and Mail, etc)
+- Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's real logged-in sessions (analyzing dashboards, checking Google Calendar and Mail, etc)
 - If a needed site is not open, opening a new tab for it is acceptable on request.
 <!--/cli-->
 

--- a/packages/claude-tandem/skills/coding/SKILL.md
+++ b/packages/claude-tandem/skills/coding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding
-description: Always use when working with code, including researching, planning changes, implementing, debugging, reviewing and refactoring
+description: Always use when working with code, including planning changes, implementing, debugging, reviewing and refactoring
 ---
 
 When working on coding tasks, you are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written. Stop at the first rung that holds:

--- a/packages/claude-tandem/skills/pr/SKILL.md
+++ b/packages/claude-tandem/skills/pr/SKILL.md
@@ -3,19 +3,13 @@ name: pr
 description: Use when asked to create or update a pull request, including branch, title and description.
 ---
 
-Before writing anything, check a few recently merged PRs in this repo and
-match their tone, length and structure.
+Before writing anything, check a few recently merged PRs in this repo and match their tone, length and structure.
 
 Title: one terse imperative line, commit-message style.
 
-Description: what changes for the user of the code, in a few short bullets or
-lines. No process narrative (test runs, review iterations), no history or
-commit archaeology - the "why" only when it changes a user decision.
+Description: what changes for the user of the code, in a few short bullets or lines. No process narrative (test runs, review iterations), no history or commit archaeology - the "why" only when it changes a user decision.
 
 Workflow:
-- Continue on the current branch; if it is main, move the commits to a
-  descriptively named branch first.
-- Before proposing, run `git log --oneline <base>..HEAD` and confirm the PR
-  would contain exactly this task's commits.
-- Propose the exact title and description to the user; create the PR only
-  after their explicit go-ahead.
+- Continue on the current branch; if it is main, move the commits to a descriptively named branch first.
+- Before proposing, run `git log --oneline <base>..HEAD` and confirm the PR would contain exactly this task's commits.
+- Propose the exact title and description to the user; create the PR only after their explicit go-ahead.

--- a/packages/claude-tandem/skills/research/SKILL.md
+++ b/packages/claude-tandem/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Use when asked to investigate or find something out - in data, documents or code
+description: Use when asked to investigate or find something out - in data, documents or code.
 ---
 
 Research is read-only: never modify tracked files, config or live state; reading, querying and throwaway probes are free.
@@ -14,15 +14,15 @@ Workflow:
 
 1. Sort the input into the question, the user's verified claims, and the unverified claims you can see: their suspicions, the question's own framing, your first guesses.
 2. Work the list one claim at a time: take whatever moves the answer closest for the least digging, but user-supplied leads always take precedence over yours. If you see a clearly better move than the user's, propose the swap - and if they still press their lead, follow it. Re-sort whenever the list changes. Try the claim:
-  - verified: move it over; queue the new claims it suggests;
-  - refuted: its opposite is verified; queue what that opens up;
-  - not directly checkable: swap it for intermediate claims that would settle it.
+   - verified: move it over; queue the new claims it suggests;
+   - refuted: its opposite is verified; queue what that opens up;
+   - not directly checkable: swap it for intermediate claims that would settle it.
 3. Verify by tracing the real thing end to end; a plausible story is not verification. "No such thing" counts only when you looked everywhere it could be - and when the answer hangs on a "no", check it again from another angle. When a probe would settle a claim more cheaply or more reliably than reading - a throwaway script, a query, a client call - probe; keep probes in a scratch directory, never the repo.
 4. Report once every part of the question is answered by verified claims.
 5. Interrupt for user input when:
-  - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
-  - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
-  - the list is empty and the question is still open: ask what else to check.
+   - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
+   - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
+   - the list is empty and the question is still open: ask what else to check.
 
 Report rules, whether it lands in chat or a file:
 

--- a/packages/claude-tandem/skills/research/SKILL.md
+++ b/packages/claude-tandem/skills/research/SKILL.md
@@ -1,41 +1,31 @@
 ---
 name: research
-description: Use when asked to investigate or find something out - in data, documents or code - without changing anything.
+description: Use when asked to investigate or find something out - in data, documents or code
 ---
 
-The deliverable is an answer someone else can check: every claim carries the
-evidence it rests on. Acting on the findings requires a separate explicit
-go-ahead.
+Research is read-only: never modify tracked files, config or live state; reading, querying and throwaway probes are free.
 
-Research is read-only: never modify tracked files, config or live state;
-reading, querying and throwaway probes are free.
+Terms:
+
+- **unverified claim** - a single statement the answer could rest on, not yet verified, so it cannot be relied upon. Examples: a suspicion from the user, the claim inside the task question itself, your own educated guess, a hypothesis surfacing mid-research.
+- **verified claim** - a claim confirmed by checked evidence, or stated by the user from their own knowledge. Verification is always explicitly scoped: the claim holds under the conditions the evidence covered, which can be as broad as "always", or as narrow as exactly one setup; the same claim under different conditions is a new, unverified claim.
 
 Workflow:
 
-1. Sort the input: the question, the user's facts - verified claims from the
-   start - and their suspicions - leads to verify or disprove, with new leads
-   arriving from either side as you go. Follow the user's leads first; when
-   you see a better one, say so - their pick stands.
-2. Trace it, don't infer it. Follow the real path end to end; a plausible
-   explanation is not the verified one.
-3. A negative is a claim like any other: it is verified by coverage - a
-   search that reached everywhere the thing could be - and any negative the
-   answer rests on gets confirmed from a second, disjoint angle.
-4. Probe whenever that settles it more easily than digging through docs or
-   code - a throwaway script, a query, a minimal client call. Keep probes in a
-   scratch directory, never in the repo.
-5. Ask one question at a time, most foundational first, and only for what you
-   cannot settle quickly yourself: user decisions, facts only the user could
-   know, or answers the user may already have.
-6. When a newly verified claim contradicts one already verified - from your
-   research or the user's input - stop and lay both before the user.
-   Resolving contradictions is their call, not yours.
+1. Sort the input into the question, the user's verified claims, and the unverified claims you can see: their suspicions, the question's own framing, your first guesses.
+2. Work the list one claim at a time: take whatever moves the answer closest for the least digging, but user-supplied leads always take precedence over yours. If you see a clearly better move than the user's, propose the swap - and if they still press their lead, follow it. Re-sort whenever the list changes. Try the claim:
+  - verified: move it over; queue the new claims it suggests;
+  - refuted: its opposite is verified; queue what that opens up;
+  - not directly checkable: swap it for intermediate claims that would settle it.
+3. Verify by tracing the real thing end to end; a plausible story is not verification. "No such thing" counts only when you looked everywhere it could be - and when the answer hangs on a "no", check it again from another angle. When a probe would settle a claim more cheaply or more reliably than reading - a throwaway script, a query, a client call - probe; keep probes in a scratch directory, never the repo.
+4. Report once every part of the question is answered by verified claims.
+5. Interrupt for user input when:
+  - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
+  - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
+  - the list is empty and the question is still open: ask what else to check.
 
 Report rules, whether it lands in chat or a file:
 
-- Lead with the answer, then the evidence. Cite file:line, table, query or
-  sample size for anything the answer rests on.
-- Only verified claims make the report - confirmed by your own research or
-  supplied by the user. A disproved claim is just the verified opposite.
-- Answer every part that was asked, including the parts with boring answers.
+- Lead with the answer, then the evidence. Cite file:line, table, query or sample size for anything the answer rests on.
+- Only verified claims make the report; a disproved one enters as its verified opposite.
 - No process narrative: what you found, not the order you found it in.

--- a/packages/claude-tandem/skills/research/SKILL.md
+++ b/packages/claude-tandem/skills/research/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: research
+description: Use when asked to investigate or find something out - in data, documents or code - without changing anything.
+---
+
+The deliverable is an answer someone else can check: every claim carries the
+evidence it rests on. Acting on the findings requires a separate explicit
+go-ahead.
+
+Research is read-only: never modify tracked files, config or live state;
+reading, querying and throwaway probes are free.
+
+Workflow:
+
+1. Sort the input: the question, the user's facts - verified claims from the
+   start - and their suspicions - leads to verify or disprove, with new leads
+   arriving from either side as you go. Follow the user's leads first; when
+   you see a better one, say so - their pick stands.
+2. Trace it, don't infer it. Follow the real path end to end; a plausible
+   explanation is not the verified one.
+3. A negative is a claim like any other: it is verified by coverage - a
+   search that reached everywhere the thing could be - and any negative the
+   answer rests on gets confirmed from a second, disjoint angle.
+4. Probe whenever that settles it more easily than digging through docs or
+   code - a throwaway script, a query, a minimal client call. Keep probes in a
+   scratch directory, never in the repo.
+5. Ask one question at a time, most foundational first, and only for what you
+   cannot settle quickly yourself: user decisions, facts only the user could
+   know, or answers the user may already have.
+6. When a newly verified claim contradicts one already verified - from your
+   research or the user's input - stop and lay both before the user.
+   Resolving contradictions is their call, not yours.
+
+Report rules, whether it lands in chat or a file:
+
+- Lead with the answer, then the evidence. Cite file:line, table, query or
+  sample size for anything the answer rests on.
+- Only verified claims make the report - confirmed by your own research or
+  supplied by the user. A disproved claim is just the verified opposite.
+- Answer every part that was asked, including the parts with boring answers.
+- No process narrative: what you found, not the order you found it in.

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -16,6 +16,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 
 - **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
 - **Skills**, loaded on demand:
+  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
   - **Brainstorming** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only

--- a/packages/pi-tandem/prompt.md
+++ b/packages/pi-tandem/prompt.md
@@ -59,8 +59,7 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pandoc` to convert documents (docx, odt, rtf, ...) to markdown: `pandoc input.docx -o output.md`
 <!--/cli-->
 <!--cli:osascript-->
-- Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's
-  real logged-in sessions (analyzing dashboards, checking Google Calendar and Mail, etc)
+- Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's real logged-in sessions (analyzing dashboards, checking Google Calendar and Mail, etc)
 - If a needed site is not open, opening a new tab for it is acceptable on request.
 <!--/cli-->
 

--- a/packages/pi-tandem/skills/coding/SKILL.md
+++ b/packages/pi-tandem/skills/coding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding
-description: Always use when working with code, including researching, planning changes, implementing, debugging, reviewing and refactoring
+description: Always use when working with code, including planning changes, implementing, debugging, reviewing and refactoring
 ---
 
 When working on coding tasks, you are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written. Stop at the first rung that holds:

--- a/packages/pi-tandem/skills/pr/SKILL.md
+++ b/packages/pi-tandem/skills/pr/SKILL.md
@@ -3,19 +3,13 @@ name: pr
 description: Use when asked to create or update a pull request, including branch, title and description.
 ---
 
-Before writing anything, check a few recently merged PRs in this repo and
-match their tone, length and structure.
+Before writing anything, check a few recently merged PRs in this repo and match their tone, length and structure.
 
 Title: one terse imperative line, commit-message style.
 
-Description: what changes for the user of the code, in a few short bullets or
-lines. No process narrative (test runs, review iterations), no history or
-commit archaeology - the "why" only when it changes a user decision.
+Description: what changes for the user of the code, in a few short bullets or lines. No process narrative (test runs, review iterations), no history or commit archaeology - the "why" only when it changes a user decision.
 
 Workflow:
-- Continue on the current branch; if it is main, move the commits to a
-  descriptively named branch first.
-- Before proposing, run `git log --oneline <base>..HEAD` and confirm the PR
-  would contain exactly this task's commits.
-- Propose the exact title and description to the user; create the PR only
-  after their explicit go-ahead.
+- Continue on the current branch; if it is main, move the commits to a descriptively named branch first.
+- Before proposing, run `git log --oneline <base>..HEAD` and confirm the PR would contain exactly this task's commits.
+- Propose the exact title and description to the user; create the PR only after their explicit go-ahead.

--- a/packages/pi-tandem/skills/research/SKILL.md
+++ b/packages/pi-tandem/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Use when asked to investigate or find something out - in data, documents or code
+description: Use when asked to investigate or find something out - in data, documents or code.
 ---
 
 Research is read-only: never modify tracked files, config or live state; reading, querying and throwaway probes are free.
@@ -14,15 +14,15 @@ Workflow:
 
 1. Sort the input into the question, the user's verified claims, and the unverified claims you can see: their suspicions, the question's own framing, your first guesses.
 2. Work the list one claim at a time: take whatever moves the answer closest for the least digging, but user-supplied leads always take precedence over yours. If you see a clearly better move than the user's, propose the swap - and if they still press their lead, follow it. Re-sort whenever the list changes. Try the claim:
-  - verified: move it over; queue the new claims it suggests;
-  - refuted: its opposite is verified; queue what that opens up;
-  - not directly checkable: swap it for intermediate claims that would settle it.
+   - verified: move it over; queue the new claims it suggests;
+   - refuted: its opposite is verified; queue what that opens up;
+   - not directly checkable: swap it for intermediate claims that would settle it.
 3. Verify by tracing the real thing end to end; a plausible story is not verification. "No such thing" counts only when you looked everywhere it could be - and when the answer hangs on a "no", check it again from another angle. When a probe would settle a claim more cheaply or more reliably than reading - a throwaway script, a query, a client call - probe; keep probes in a scratch directory, never the repo.
 4. Report once every part of the question is answered by verified claims.
 5. Interrupt for user input when:
-  - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
-  - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
-  - the list is empty and the question is still open: ask what else to check.
+   - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
+   - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
+   - the list is empty and the question is still open: ask what else to check.
 
 Report rules, whether it lands in chat or a file:
 

--- a/packages/pi-tandem/skills/research/SKILL.md
+++ b/packages/pi-tandem/skills/research/SKILL.md
@@ -1,41 +1,31 @@
 ---
 name: research
-description: Use when asked to investigate or find something out - in data, documents or code - without changing anything.
+description: Use when asked to investigate or find something out - in data, documents or code
 ---
 
-The deliverable is an answer someone else can check: every claim carries the
-evidence it rests on. Acting on the findings requires a separate explicit
-go-ahead.
+Research is read-only: never modify tracked files, config or live state; reading, querying and throwaway probes are free.
 
-Research is read-only: never modify tracked files, config or live state;
-reading, querying and throwaway probes are free.
+Terms:
+
+- **unverified claim** - a single statement the answer could rest on, not yet verified, so it cannot be relied upon. Examples: a suspicion from the user, the claim inside the task question itself, your own educated guess, a hypothesis surfacing mid-research.
+- **verified claim** - a claim confirmed by checked evidence, or stated by the user from their own knowledge. Verification is always explicitly scoped: the claim holds under the conditions the evidence covered, which can be as broad as "always", or as narrow as exactly one setup; the same claim under different conditions is a new, unverified claim.
 
 Workflow:
 
-1. Sort the input: the question, the user's facts - verified claims from the
-   start - and their suspicions - leads to verify or disprove, with new leads
-   arriving from either side as you go. Follow the user's leads first; when
-   you see a better one, say so - their pick stands.
-2. Trace it, don't infer it. Follow the real path end to end; a plausible
-   explanation is not the verified one.
-3. A negative is a claim like any other: it is verified by coverage - a
-   search that reached everywhere the thing could be - and any negative the
-   answer rests on gets confirmed from a second, disjoint angle.
-4. Probe whenever that settles it more easily than digging through docs or
-   code - a throwaway script, a query, a minimal client call. Keep probes in a
-   scratch directory, never in the repo.
-5. Ask one question at a time, most foundational first, and only for what you
-   cannot settle quickly yourself: user decisions, facts only the user could
-   know, or answers the user may already have.
-6. When a newly verified claim contradicts one already verified - from your
-   research or the user's input - stop and lay both before the user.
-   Resolving contradictions is their call, not yours.
+1. Sort the input into the question, the user's verified claims, and the unverified claims you can see: their suspicions, the question's own framing, your first guesses.
+2. Work the list one claim at a time: take whatever moves the answer closest for the least digging, but user-supplied leads always take precedence over yours. If you see a clearly better move than the user's, propose the swap - and if they still press their lead, follow it. Re-sort whenever the list changes. Try the claim:
+  - verified: move it over; queue the new claims it suggests;
+  - refuted: its opposite is verified; queue what that opens up;
+  - not directly checkable: swap it for intermediate claims that would settle it.
+3. Verify by tracing the real thing end to end; a plausible story is not verification. "No such thing" counts only when you looked everywhere it could be - and when the answer hangs on a "no", check it again from another angle. When a probe would settle a claim more cheaply or more reliably than reading - a throwaway script, a query, a client call - probe; keep probes in a scratch directory, never the repo.
+4. Report once every part of the question is answered by verified claims.
+5. Interrupt for user input when:
+  - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
+  - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
+  - the list is empty and the question is still open: ask what else to check.
 
 Report rules, whether it lands in chat or a file:
 
-- Lead with the answer, then the evidence. Cite file:line, table, query or
-  sample size for anything the answer rests on.
-- Only verified claims make the report - confirmed by your own research or
-  supplied by the user. A disproved claim is just the verified opposite.
-- Answer every part that was asked, including the parts with boring answers.
+- Lead with the answer, then the evidence. Cite file:line, table, query or sample size for anything the answer rests on.
+- Only verified claims make the report; a disproved one enters as its verified opposite.
 - No process narrative: what you found, not the order you found it in.

--- a/packages/pi-tandem/skills/research/SKILL.md
+++ b/packages/pi-tandem/skills/research/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: research
+description: Use when asked to investigate or find something out - in data, documents or code - without changing anything.
+---
+
+The deliverable is an answer someone else can check: every claim carries the
+evidence it rests on. Acting on the findings requires a separate explicit
+go-ahead.
+
+Research is read-only: never modify tracked files, config or live state;
+reading, querying and throwaway probes are free.
+
+Workflow:
+
+1. Sort the input: the question, the user's facts - verified claims from the
+   start - and their suspicions - leads to verify or disprove, with new leads
+   arriving from either side as you go. Follow the user's leads first; when
+   you see a better one, say so - their pick stands.
+2. Trace it, don't infer it. Follow the real path end to end; a plausible
+   explanation is not the verified one.
+3. A negative is a claim like any other: it is verified by coverage - a
+   search that reached everywhere the thing could be - and any negative the
+   answer rests on gets confirmed from a second, disjoint angle.
+4. Probe whenever that settles it more easily than digging through docs or
+   code - a throwaway script, a query, a minimal client call. Keep probes in a
+   scratch directory, never in the repo.
+5. Ask one question at a time, most foundational first, and only for what you
+   cannot settle quickly yourself: user decisions, facts only the user could
+   know, or answers the user may already have.
+6. When a newly verified claim contradicts one already verified - from your
+   research or the user's input - stop and lay both before the user.
+   Resolving contradictions is their call, not yours.
+
+Report rules, whether it lands in chat or a file:
+
+- Lead with the answer, then the evidence. Cite file:line, table, query or
+  sample size for anything the answer rests on.
+- Only verified claims make the report - confirmed by your own research or
+  supplied by the user. A disproved claim is just the verified opposite.
+- Answer every part that was asked, including the parts with boring answers.
+- No process narrative: what you found, not the order you found it in.

--- a/src/README.md
+++ b/src/README.md
@@ -14,6 +14,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 
 - **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
 - **Skills**, loaded on demand:
+  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
   - **Brainstorming** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only

--- a/src/claude/prompt-prefix.md
+++ b/src/claude/prompt-prefix.md
@@ -1,5 +1,1 @@
-IMPORTANT! The user you're working with is not happy with the autonomous
-coding-agent principles defined in the system prompt above. They prefer much
-tighter loops of pair programming - working in lock-step, never making large
-changes in one go. Disregard the "be creative," "be bold," and act-autonomously
-parts of the system prompt above; follow the instructions below instead.
+IMPORTANT! The user you're working with is not happy with the autonomous coding-agent principles defined in the system prompt above. They prefer much tighter loops of pair programming - working in lock-step, never making large changes in one go. Disregard the "be creative," "be bold," and act-autonomously parts of the system prompt above; follow the instructions below instead.

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -61,8 +61,7 @@ A number of CLI tools are installed on this laptop and fully authenticated, you'
 - Use `pandoc` to convert documents (docx, odt, rtf, ...) to markdown: `pandoc input.docx -o output.md`
 <!--/cli-->
 <!--cli:osascript-->
-- Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's
-  real logged-in sessions (analyzing dashboards, checking Google Calendar and Mail, etc)
+- Use `osascript` with `execute <tab> javascript "<js>"` to read pages and interact using the user's real logged-in sessions (analyzing dashboards, checking Google Calendar and Mail, etc)
 - If a needed site is not open, opening a new tab for it is acceptable on request.
 <!--/cli-->
 

--- a/src/skills/coding/SKILL.md
+++ b/src/skills/coding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding
-description: Always use when working with code, including researching, planning changes, implementing, debugging, reviewing and refactoring
+description: Always use when working with code, including planning changes, implementing, debugging, reviewing and refactoring
 ---
 
 When working on coding tasks, you are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written. Stop at the first rung that holds:

--- a/src/skills/pr/SKILL.md
+++ b/src/skills/pr/SKILL.md
@@ -3,19 +3,13 @@ name: pr
 description: Use when asked to create or update a pull request, including branch, title and description.
 ---
 
-Before writing anything, check a few recently merged PRs in this repo and
-match their tone, length and structure.
+Before writing anything, check a few recently merged PRs in this repo and match their tone, length and structure.
 
 Title: one terse imperative line, commit-message style.
 
-Description: what changes for the user of the code, in a few short bullets or
-lines. No process narrative (test runs, review iterations), no history or
-commit archaeology - the "why" only when it changes a user decision.
+Description: what changes for the user of the code, in a few short bullets or lines. No process narrative (test runs, review iterations), no history or commit archaeology - the "why" only when it changes a user decision.
 
 Workflow:
-- Continue on the current branch; if it is main, move the commits to a
-  descriptively named branch first.
-- Before proposing, run `git log --oneline <base>..HEAD` and confirm the PR
-  would contain exactly this task's commits.
-- Propose the exact title and description to the user; create the PR only
-  after their explicit go-ahead.
+- Continue on the current branch; if it is main, move the commits to a descriptively named branch first.
+- Before proposing, run `git log --oneline <base>..HEAD` and confirm the PR would contain exactly this task's commits.
+- Propose the exact title and description to the user; create the PR only after their explicit go-ahead.

--- a/src/skills/research/SKILL.md
+++ b/src/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Use when asked to investigate or find something out - in data, documents or code
+description: Use when asked to investigate or find something out - in data, documents or code.
 ---
 
 Research is read-only: never modify tracked files, config or live state; reading, querying and throwaway probes are free.
@@ -14,15 +14,15 @@ Workflow:
 
 1. Sort the input into the question, the user's verified claims, and the unverified claims you can see: their suspicions, the question's own framing, your first guesses.
 2. Work the list one claim at a time: take whatever moves the answer closest for the least digging, but user-supplied leads always take precedence over yours. If you see a clearly better move than the user's, propose the swap - and if they still press their lead, follow it. Re-sort whenever the list changes. Try the claim:
-  - verified: move it over; queue the new claims it suggests;
-  - refuted: its opposite is verified; queue what that opens up;
-  - not directly checkable: swap it for intermediate claims that would settle it.
+   - verified: move it over; queue the new claims it suggests;
+   - refuted: its opposite is verified; queue what that opens up;
+   - not directly checkable: swap it for intermediate claims that would settle it.
 3. Verify by tracing the real thing end to end; a plausible story is not verification. "No such thing" counts only when you looked everywhere it could be - and when the answer hangs on a "no", check it again from another angle. When a probe would settle a claim more cheaply or more reliably than reading - a throwaway script, a query, a client call - probe; keep probes in a scratch directory, never the repo.
 4. Report once every part of the question is answered by verified claims.
 5. Interrupt for user input when:
-  - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
-  - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
-  - the list is empty and the question is still open: ask what else to check.
+   - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
+   - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
+   - the list is empty and the question is still open: ask what else to check.
 
 Report rules, whether it lands in chat or a file:
 

--- a/src/skills/research/SKILL.md
+++ b/src/skills/research/SKILL.md
@@ -1,41 +1,31 @@
 ---
 name: research
-description: Use when asked to investigate or find something out - in data, documents or code - without changing anything.
+description: Use when asked to investigate or find something out - in data, documents or code
 ---
 
-The deliverable is an answer someone else can check: every claim carries the
-evidence it rests on. Acting on the findings requires a separate explicit
-go-ahead.
+Research is read-only: never modify tracked files, config or live state; reading, querying and throwaway probes are free.
 
-Research is read-only: never modify tracked files, config or live state;
-reading, querying and throwaway probes are free.
+Terms:
+
+- **unverified claim** - a single statement the answer could rest on, not yet verified, so it cannot be relied upon. Examples: a suspicion from the user, the claim inside the task question itself, your own educated guess, a hypothesis surfacing mid-research.
+- **verified claim** - a claim confirmed by checked evidence, or stated by the user from their own knowledge. Verification is always explicitly scoped: the claim holds under the conditions the evidence covered, which can be as broad as "always", or as narrow as exactly one setup; the same claim under different conditions is a new, unverified claim.
 
 Workflow:
 
-1. Sort the input: the question, the user's facts - verified claims from the
-   start - and their suspicions - leads to verify or disprove, with new leads
-   arriving from either side as you go. Follow the user's leads first; when
-   you see a better one, say so - their pick stands.
-2. Trace it, don't infer it. Follow the real path end to end; a plausible
-   explanation is not the verified one.
-3. A negative is a claim like any other: it is verified by coverage - a
-   search that reached everywhere the thing could be - and any negative the
-   answer rests on gets confirmed from a second, disjoint angle.
-4. Probe whenever that settles it more easily than digging through docs or
-   code - a throwaway script, a query, a minimal client call. Keep probes in a
-   scratch directory, never in the repo.
-5. Ask one question at a time, most foundational first, and only for what you
-   cannot settle quickly yourself: user decisions, facts only the user could
-   know, or answers the user may already have.
-6. When a newly verified claim contradicts one already verified - from your
-   research or the user's input - stop and lay both before the user.
-   Resolving contradictions is their call, not yours.
+1. Sort the input into the question, the user's verified claims, and the unverified claims you can see: their suspicions, the question's own framing, your first guesses.
+2. Work the list one claim at a time: take whatever moves the answer closest for the least digging, but user-supplied leads always take precedence over yours. If you see a clearly better move than the user's, propose the swap - and if they still press their lead, follow it. Re-sort whenever the list changes. Try the claim:
+  - verified: move it over; queue the new claims it suggests;
+  - refuted: its opposite is verified; queue what that opens up;
+  - not directly checkable: swap it for intermediate claims that would settle it.
+3. Verify by tracing the real thing end to end; a plausible story is not verification. "No such thing" counts only when you looked everywhere it could be - and when the answer hangs on a "no", check it again from another angle. When a probe would settle a claim more cheaply or more reliably than reading - a throwaway script, a query, a client call - probe; keep probes in a scratch directory, never the repo.
+4. Report once every part of the question is answered by verified claims.
+5. Interrupt for user input when:
+  - a new verification contradicts a verified claim: lay both out; resolving contradictions is their call, not yours;
+  - the next best claim is expensive to verify - deep digging, data crunching, a real bite of session context - and the user may know or point somewhere cheaper;
+  - the list is empty and the question is still open: ask what else to check.
 
 Report rules, whether it lands in chat or a file:
 
-- Lead with the answer, then the evidence. Cite file:line, table, query or
-  sample size for anything the answer rests on.
-- Only verified claims make the report - confirmed by your own research or
-  supplied by the user. A disproved claim is just the verified opposite.
-- Answer every part that was asked, including the parts with boring answers.
+- Lead with the answer, then the evidence. Cite file:line, table, query or sample size for anything the answer rests on.
+- Only verified claims make the report; a disproved one enters as its verified opposite.
 - No process narrative: what you found, not the order you found it in.

--- a/src/skills/research/SKILL.md
+++ b/src/skills/research/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: research
+description: Use when asked to investigate or find something out - in data, documents or code - without changing anything.
+---
+
+The deliverable is an answer someone else can check: every claim carries the
+evidence it rests on. Acting on the findings requires a separate explicit
+go-ahead.
+
+Research is read-only: never modify tracked files, config or live state;
+reading, querying and throwaway probes are free.
+
+Workflow:
+
+1. Sort the input: the question, the user's facts - verified claims from the
+   start - and their suspicions - leads to verify or disprove, with new leads
+   arriving from either side as you go. Follow the user's leads first; when
+   you see a better one, say so - their pick stands.
+2. Trace it, don't infer it. Follow the real path end to end; a plausible
+   explanation is not the verified one.
+3. A negative is a claim like any other: it is verified by coverage - a
+   search that reached everywhere the thing could be - and any negative the
+   answer rests on gets confirmed from a second, disjoint angle.
+4. Probe whenever that settles it more easily than digging through docs or
+   code - a throwaway script, a query, a minimal client call. Keep probes in a
+   scratch directory, never in the repo.
+5. Ask one question at a time, most foundational first, and only for what you
+   cannot settle quickly yourself: user decisions, facts only the user could
+   know, or answers the user may already have.
+6. When a newly verified claim contradicts one already verified - from your
+   research or the user's input - stop and lay both before the user.
+   Resolving contradictions is their call, not yours.
+
+Report rules, whether it lands in chat or a file:
+
+- Lead with the answer, then the evidence. Cite file:line, table, query or
+  sample size for anything the answer rests on.
+- Only verified claims make the report - confirmed by your own research or
+  supplied by the user. A disproved claim is just the verified opposite.
+- Answer every part that was asked, including the parts with boring answers.
+- No process narrative: what you found, not the order you found it in.


### PR DESCRIPTION
- New on-demand `research` skill: read-only investigation that answers a question by working a list of claims - verified ones carry the answer, unverified ones are leads to check, refute or decompose; user-supplied leads outrank the agent's own
- Interrupts for user input on contradictions between verified claims, before expensive verifications, and when the lead list runs dry
- Reports carry only verified claims with their evidence - a plausible guess or a narrative of dead ends never makes it
- Skills list in the READMEs gains Research, first in line ahead of Brainstorming
- Markdown documents are no longer hard-wrapped (one paragraph per line), per a new AGENTS.md rule; scripts and code blocks untouched