### PR TITLE
Improve documentation, clean up repo a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,19 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-- **Interactive subagent workflow** to run a task in a fresh session on request (a new tmux window or a background paseo agent), with full visibility and control
+- **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
 - **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+
+## Interactive subagents
+
+In most harnesses a subagent is fire-and-forget: a one-shot call - prompt in, result out, no interaction while it runs - and the full result lands in the parent's context. Tandem keeps the point of the idea - a task runs in a fresh context and reports back, sparing the parent's context the intermediate steps - but drops the fire-and-forget part:
+
+- the worker is a normal agent session with the same skills: you can watch it work and talk to it mid-task
+- nothing flows back until you check and approve the result in the worker's chat; only the result - usually far smaller than the worker's full transcript - is loaded into the parent's context
+
+The workflow needs the main session to run inside tmux or paseo. To start a worker, tell the current agent "use a subagent" or "do it in a fresh session": it spawns a new session using the available mechanism - a tmux window, or a parallel paseo agent - and hands it a fully self-contained task; the worker never sees the parent session's history. Workers can spawn subagents of their own, so the delegation nests.
+
+The idea first shipped in [pi-supergsd](https://github.com/skhoroshavin/pi-supergsd), Pi-only, with tasks running as branches in the Pi session tree instead of separate sessions.
 
 ## Recommended tools
 
@@ -45,7 +56,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 - `pandoc` - convert docx/odt/rtf to markdown
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript
 - `jira`, `aws`, `saml2aws` - if your workflow includes them
-- `tmux` or `paseo` - run the main session inside one of these to get the interactive subagent workflow
+- `tmux` or `paseo` - run the main session inside one of these to enable [interactive subagents](#interactive-subagents)
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 - **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
 - **Skills**, loaded on demand:
   - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
-  - **Brainstorming** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
+  - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
@@ -51,7 +51,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 
 The "lazy senior" part of the coding skill is adapted from [ponytail](https://github.com/DietrichGebert/ponytail) by DietrichGebert (MIT).
 
-The brainstorming skill's interview method (facts vs. decisions, one question at a time, throwaway probes) is inspired by ideas from the brainstorming skill in [superpowers](https://github.com/obra/superpowers) by obra and the grilling skill in [skills](https://github.com/mattpocock/skills) by mattpocock (both MIT).
+The brainstorm skill's interview method (facts vs. decisions, one question at a time, throwaway probes) is inspired by ideas from the brainstorming skill in [superpowers](https://github.com/obra/superpowers) by obra and the grilling skill in [skills](https://github.com/mattpocock/skills) by mattpocock (both MIT).
 
 ## License
 

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -22,8 +22,19 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-- **Interactive subagent workflow** to run a task in a fresh session on request (a new tmux window or a background paseo agent), with full visibility and control
+- **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
 - **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+
+## Interactive subagents
+
+In most harnesses a subagent is fire-and-forget: a one-shot call - prompt in, result out, no interaction while it runs - and the full result lands in the parent's context. Tandem keeps the point of the idea - a task runs in a fresh context and reports back, sparing the parent's context the intermediate steps - but drops the fire-and-forget part:
+
+- the worker is a normal agent session with the same skills: you can watch it work and talk to it mid-task
+- nothing flows back until you check and approve the result in the worker's chat; only the result - usually far smaller than the worker's full transcript - is loaded into the parent's context
+
+The workflow needs the main session to run inside tmux or paseo. To start a worker, tell the current agent "use a subagent" or "do it in a fresh session": it spawns a new session using the available mechanism - a tmux window, or a parallel paseo agent - and hands it a fully self-contained task; the worker never sees the parent session's history. Workers can spawn subagents of their own, so the delegation nests.
+
+The idea first shipped in [pi-supergsd](https://github.com/skhoroshavin/pi-supergsd), Pi-only, with tasks running as branches in the Pi session tree instead of separate sessions.
 
 ## Recommended tools
 
@@ -37,7 +48,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 - `pandoc` - convert docx/odt/rtf to markdown
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript
 - `jira`, `aws`, `saml2aws` - if your workflow includes them
-- `tmux` or `paseo` - run the main session inside one of these to get the interactive subagent workflow
+- `tmux` or `paseo` - run the main session inside one of these to enable [interactive subagents](#interactive-subagents)
 
 ## Attribution
 

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -18,7 +18,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 - **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
 - **Skills**, loaded on demand:
   - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
-  - **Brainstorming** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
+  - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
@@ -43,7 +43,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 
 The "lazy senior" part of the coding skill is adapted from [ponytail](https://github.com/DietrichGebert/ponytail) by DietrichGebert (MIT).
 
-The brainstorming skill's interview method (facts vs. decisions, one question at a time, throwaway probes) is inspired by ideas from the brainstorming skill in [superpowers](https://github.com/obra/superpowers) by obra and the grilling skill in [skills](https://github.com/mattpocock/skills) by mattpocock (both MIT).
+The brainstorm skill's interview method (facts vs. decisions, one question at a time, throwaway probes) is inspired by ideas from the brainstorming skill in [superpowers](https://github.com/obra/superpowers) by obra and the grilling skill in [skills](https://github.com/mattpocock/skills) by mattpocock (both MIT).
 
 ## License
 

--- a/packages/claude-tandem/skills/brainstorm/SKILL.md
+++ b/packages/claude-tandem/skills/brainstorm/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: brainstorming
+name: brainstorm
 description: Use when asked to discuss or brainstorm something - an idea, design, plan.
 ---
 

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -21,8 +21,19 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-- **Interactive subagent workflow** to run a task in a fresh session on request (a new tmux window or a background paseo agent), with full visibility and control
+- **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
 - **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+
+## Interactive subagents
+
+In most harnesses a subagent is fire-and-forget: a one-shot call - prompt in, result out, no interaction while it runs - and the full result lands in the parent's context. Tandem keeps the point of the idea - a task runs in a fresh context and reports back, sparing the parent's context the intermediate steps - but drops the fire-and-forget part:
+
+- the worker is a normal agent session with the same skills: you can watch it work and talk to it mid-task
+- nothing flows back until you check and approve the result in the worker's chat; only the result - usually far smaller than the worker's full transcript - is loaded into the parent's context
+
+The workflow needs the main session to run inside tmux or paseo. To start a worker, tell the current agent "use a subagent" or "do it in a fresh session": it spawns a new session using the available mechanism - a tmux window, or a parallel paseo agent - and hands it a fully self-contained task; the worker never sees the parent session's history. Workers can spawn subagents of their own, so the delegation nests.
+
+The idea first shipped in [pi-supergsd](https://github.com/skhoroshavin/pi-supergsd), Pi-only, with tasks running as branches in the Pi session tree instead of separate sessions.
 
 ## Recommended tools
 
@@ -36,7 +47,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 - `pandoc` - convert docx/odt/rtf to markdown
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript
 - `jira`, `aws`, `saml2aws` - if your workflow includes them
-- `tmux` or `paseo` - run the main session inside one of these to get the interactive subagent workflow
+- `tmux` or `paseo` - run the main session inside one of these to enable [interactive subagents](#interactive-subagents)
 
 ## Attribution
 

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -17,7 +17,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 - **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
 - **Skills**, loaded on demand:
   - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
-  - **Brainstorming** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
+  - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
@@ -42,7 +42,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 
 The "lazy senior" part of the coding skill is adapted from [ponytail](https://github.com/DietrichGebert/ponytail) by DietrichGebert (MIT).
 
-The brainstorming skill's interview method (facts vs. decisions, one question at a time, throwaway probes) is inspired by ideas from the brainstorming skill in [superpowers](https://github.com/obra/superpowers) by obra and the grilling skill in [skills](https://github.com/mattpocock/skills) by mattpocock (both MIT).
+The brainstorm skill's interview method (facts vs. decisions, one question at a time, throwaway probes) is inspired by ideas from the brainstorming skill in [superpowers](https://github.com/obra/superpowers) by obra and the grilling skill in [skills](https://github.com/mattpocock/skills) by mattpocock (both MIT).
 
 ## License
 

--- a/packages/pi-tandem/skills/brainstorm/SKILL.md
+++ b/packages/pi-tandem/skills/brainstorm/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: brainstorming
+name: brainstorm
 description: Use when asked to discuss or brainstorm something - an idea, design, plan.
 ---
 

--- a/src/README.md
+++ b/src/README.md
@@ -19,8 +19,19 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-- **Interactive subagent workflow** to run a task in a fresh session on request (a new tmux window or a background paseo agent), with full visibility and control
+- **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
 - **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+
+## Interactive subagents
+
+In most harnesses a subagent is fire-and-forget: a one-shot call - prompt in, result out, no interaction while it runs - and the full result lands in the parent's context. Tandem keeps the point of the idea - a task runs in a fresh context and reports back, sparing the parent's context the intermediate steps - but drops the fire-and-forget part:
+
+- the worker is a normal agent session with the same skills: you can watch it work and talk to it mid-task
+- nothing flows back until you check and approve the result in the worker's chat; only the result - usually far smaller than the worker's full transcript - is loaded into the parent's context
+
+The workflow needs the main session to run inside tmux or paseo. To start a worker, tell the current agent "use a subagent" or "do it in a fresh session": it spawns a new session using the available mechanism - a tmux window, or a parallel paseo agent - and hands it a fully self-contained task; the worker never sees the parent session's history. Workers can spawn subagents of their own, so the delegation nests.
+
+The idea first shipped in [pi-supergsd](https://github.com/skhoroshavin/pi-supergsd), Pi-only, with tasks running as branches in the Pi session tree instead of separate sessions.
 
 ## Recommended tools
 
@@ -34,7 +45,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 - `pandoc` - convert docx/odt/rtf to markdown
 - `osascript` (macOS only) - drive the user's real browser sessions via AppleScript
 - `jira`, `aws`, `saml2aws` - if your workflow includes them
-- `tmux` or `paseo` - run the main session inside one of these to get the interactive subagent workflow
+- `tmux` or `paseo` - run the main session inside one of these to enable [interactive subagents](#interactive-subagents)
 
 ## Attribution
 

--- a/src/README.md
+++ b/src/README.md
@@ -15,7 +15,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
 - **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
 - **Skills**, loaded on demand:
   - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
-  - **Brainstorming** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
+  - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
@@ -40,7 +40,7 @@ The plugin notices which CLI tools are actually installed on your machine, and f
 
 The "lazy senior" part of the coding skill is adapted from [ponytail](https://github.com/DietrichGebert/ponytail) by DietrichGebert (MIT).
 
-The brainstorming skill's interview method (facts vs. decisions, one question at a time, throwaway probes) is inspired by ideas from the brainstorming skill in [superpowers](https://github.com/obra/superpowers) by obra and the grilling skill in [skills](https://github.com/mattpocock/skills) by mattpocock (both MIT).
+The brainstorm skill's interview method (facts vs. decisions, one question at a time, throwaway probes) is inspired by ideas from the brainstorming skill in [superpowers](https://github.com/obra/superpowers) by obra and the grilling skill in [skills](https://github.com/mattpocock/skills) by mattpocock (both MIT).
 
 ## License
 

--- a/src/skills/brainstorm/SKILL.md
+++ b/src/skills/brainstorm/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: brainstorming
+name: brainstorm
 description: Use when asked to discuss or brainstorm something - an idea, design, plan.
 ---
 


### PR DESCRIPTION
- `brainstorming` skill renamed to `brainstorm`, matching the one-word noun naming of research, review, coding and pr; description and upstream attribution untouched
- READMEs gain an "Interactive subagents" section: fresh-context workers you can watch and steer mid-task, approval gate before anything flows back, nestable delegation; contrasted with the usual fire-and-forget subagents
- Feature bullet and the tmux/paseo line in recommended tools now point to the section
- Links [pi-supergsd](https://github.com/skhoroshavin/pi-supergsd) as the Pi-only predecessor (session-tree branches instead of separate sessions)