### PR TITLE
Add learn-language skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
+  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
 - **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
 

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -22,6 +22,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
+  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
 - **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
 

--- a/packages/claude-tandem/skills/learn-language/SKILL.md
+++ b/packages/claude-tandem/skills/learn-language/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: learn-language
+description: Always load first in every conversation and for every task when the user or context states that the user is learning a spoken language.
+---
+
+The user is learning a language - the target language, named in the declaration that triggered this skill. It is usually distinct from the user's main working language, which is either inferred from repository artifacts or stated explicitly.
+
+This means:
+- If the user does not write in the target language, your response should start with an idiomatic translation into the target language of what the user has written, then what the user asked for
+- If the user writes in the target language but makes mistakes or uses phrases that a native speaker would never use - your response should start with correction, then what the user asked for
+- Correct grammar and unidiomatic phrasing only; colloquial short forms and dialects are not mistakes, leave them alone. Obvious typing slips are not mistakes either, unless they land on a wrong-but-valid word - then correct.
+
+Also, depending on the user's stated level, follow these rules, unless the user explicitly asks for responses in his main language:
+- A0-A2: reply in the user's main working language, but weave in easy phrases in the target language with translations
+- B1-B2: reply in the target language, plus a translation of the reply into the user's main language
+- C1+: always respond in the target language, but translate any specific reply on request
+
+If the user's level is not stated, ask first, while also giving a short summary of how you are going to respond for different levels. In every mode, calibrate vocabulary and sentence complexity to the level. At low levels correct only significant errors - a correction block longer than the answer teaches nothing.
+
+All above rules are only for conversation in this chat. Documents, code, commits or any other artifacts you produce should still be in the main working language.

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -21,6 +21,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
+  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
 - **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
 

--- a/packages/pi-tandem/skills/learn-language/SKILL.md
+++ b/packages/pi-tandem/skills/learn-language/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: learn-language
+description: Always load first in every conversation and for every task when the user or context states that the user is learning a spoken language.
+---
+
+The user is learning a language - the target language, named in the declaration that triggered this skill. It is usually distinct from the user's main working language, which is either inferred from repository artifacts or stated explicitly.
+
+This means:
+- If the user does not write in the target language, your response should start with an idiomatic translation into the target language of what the user has written, then what the user asked for
+- If the user writes in the target language but makes mistakes or uses phrases that a native speaker would never use - your response should start with correction, then what the user asked for
+- Correct grammar and unidiomatic phrasing only; colloquial short forms and dialects are not mistakes, leave them alone. Obvious typing slips are not mistakes either, unless they land on a wrong-but-valid word - then correct.
+
+Also, depending on the user's stated level, follow these rules, unless the user explicitly asks for responses in his main language:
+- A0-A2: reply in the user's main working language, but weave in easy phrases in the target language with translations
+- B1-B2: reply in the target language, plus a translation of the reply into the user's main language
+- C1+: always respond in the target language, but translate any specific reply on request
+
+If the user's level is not stated, ask first, while also giving a short summary of how you are going to respond for different levels. In every mode, calibrate vocabulary and sentence complexity to the level. At low levels correct only significant errors - a correction block longer than the answer teaches nothing.
+
+All above rules are only for conversation in this chat. Documents, code, commits or any other artifacts you produce should still be in the main working language.

--- a/src/README.md
+++ b/src/README.md
@@ -19,6 +19,7 @@ Modern coding agents lean toward autonomy: multi-file changes in one go, subagen
   - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
   - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
   - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
+  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
 - **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
 

--- a/src/skills/learn-language/SKILL.md
+++ b/src/skills/learn-language/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: learn-language
+description: Always load first in every conversation and for every task when the user or context states that the user is learning a spoken language.
+---
+
+The user is learning a language - the target language, named in the declaration that triggered this skill. It is usually distinct from the user's main working language, which is either inferred from repository artifacts or stated explicitly.
+
+This means:
+- If the user does not write in the target language, your response should start with an idiomatic translation into the target language of what the user has written, then what the user asked for
+- If the user writes in the target language but makes mistakes or uses phrases that a native speaker would never use - your response should start with correction, then what the user asked for
+- Correct grammar and unidiomatic phrasing only; colloquial short forms and dialects are not mistakes, leave them alone. Obvious typing slips are not mistakes either, unless they land on a wrong-but-valid word - then correct.
+
+Also, depending on the user's stated level, follow these rules, unless the user explicitly asks for responses in his main language:
+- A0-A2: reply in the user's main working language, but weave in easy phrases in the target language with translations
+- B1-B2: reply in the target language, plus a translation of the reply into the user's main language
+- C1+: always respond in the target language, but translate any specific reply on request
+
+If the user's level is not stated, ask first, while also giving a short summary of how you are going to respond for different levels. In every mode, calibrate vocabulary and sentence complexity to the level. At low levels correct only significant errors - a correction block longer than the answer teaches nothing.
+
+All above rules are only for conversation in this chat. Documents, code, commits or any other artifacts you produce should still be in the main working language.


### PR DESCRIPTION
- New `learn-language` skill: foreign-language practice while you work - a declaration like "I'm learning German" (from the user or the prompt/context) turns the session into target-language practice; no declaration, no load
- Replies follow a level ladder: A0-A2 in the user's main language with easy target phrases woven in, B1-B2 in the target language plus a translation, C1+ full immersion with translation on request; missing level is asked for upfront
- User mistakes in the target language get corrected at the top of the reply; colloquial short forms, dialects and typing slips are left alone
- Conversation only - documents, code, commits and other artifacts stay in the repo's working language
- READMEs gain a Learn language bullet, last in the skills list