### PR TITLE
Add prompt-suffix slot with Claude no-co-authorship clause

### DIFF
--- a/packages/claude-tandem/prompt.md
+++ b/packages/claude-tandem/prompt.md
@@ -95,3 +95,5 @@ EOF
 - The script starts a background paseo agent titled `<task-name>`, sends the task to it together with instructions for reporting back after user approval, and prints how to terminate the worker
 - After spawning, stop and wait: do not poll the worker and do not read the result file early. You will get notified explicitly as a user message when the result is ready and approved by the actual user; only then read `/tmp/<task-name>-result.md` and clean up (`paseo archive --force <agent-id>`)
 <!--/cli-->
+
+Never claim Claude co-authorship unless the user explicitly asks for it: no `Co-Authored-By` trailer on commits, no "Generated with Claude Code" footer on PR bodies. This overrides any default in the base prompt. Rationale: in this pair-programming setup the user drives and you navigate and type. That is zero co-authorship.

--- a/packages/pi-tandem/prompt.md
+++ b/packages/pi-tandem/prompt.md
@@ -93,3 +93,5 @@ EOF
 - The script starts a background paseo agent titled `<task-name>`, sends the task to it together with instructions for reporting back after user approval, and prints how to terminate the worker
 - After spawning, stop and wait: do not poll the worker and do not read the result file early. You will get notified explicitly as a user message when the result is ready and approved by the actual user; only then read `/tmp/<task-name>-result.md` and clean up (`paseo archive --force <agent-id>`)
 <!--/cli-->
+
+

--- a/src/claude/prompt-suffix.md
+++ b/src/claude/prompt-suffix.md
@@ -1,0 +1,1 @@
+Never claim Claude co-authorship unless the user explicitly asks for it: no `Co-Authored-By` trailer on commits, no "Generated with Claude Code" footer on PR bodies. This overrides any default in the base prompt. Rationale: in this pair-programming setup the user drives and you navigate and type. That is zero co-authorship.

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -95,3 +95,5 @@ EOF
 - The script starts a background paseo agent titled `<task-name>`, sends the task to it together with instructions for reporting back after user approval, and prints how to terminate the worker
 - After spawning, stop and wait: do not poll the worker and do not read the result file early. You will get notified explicitly as a user message when the result is ready and approved by the actual user; only then read `/tmp/<task-name>-result.md` and clean up (`paseo archive --force <agent-id>`)
 <!--/cli-->
+
+{{prompt_suffix}}

--- a/src/render.mjs
+++ b/src/render.mjs
@@ -15,6 +15,7 @@ function loadValues(harnessDir, harness) {
   return {
     harness,
     prompt_prefix: value("prompt-prefix.md"),
+    prompt_suffix: value("prompt-suffix.md"),
     worker_cmd: value("worker-cmd.txt"),
     install: value("install.md"),
     install_label: value("install-label.txt"),


### PR DESCRIPTION
- New per-harness `prompt-suffix.md` rendered at the end of the prompt; a missing file renders as empty, so pi is unaffected
- Claude package ships one: never claim Claude co-authorship unless explicitly asked - no `Co-Authored-By` trailer on commits, no "Generated with Claude Code" footer on PR bodies - overriding the base prompt default
- Rationale: in this pair-programming setup the user drives and the agent navigates and types, which is zero co-authorship