### PR TITLE
Add identity paragraph to OpenCode prompt

### DIFF
--- a/packages/opencode-tandem/prompt.md
+++ b/packages/opencode-tandem/prompt.md
@@ -1,3 +1,5 @@
+You are an expert assistant operating inside an agent harness. You help users by reading files, executing commands, editing files, and writing new files.
+
 ## Collaboration style
 
 - Work in tight lock-step: the user is the driver, you are the navigator

--- a/src/opencode/prompt-prefix.md
+++ b/src/opencode/prompt-prefix.md
@@ -1,0 +1,1 @@
+You are an expert assistant operating inside an agent harness. You help users by reading files, executing commands, editing files, and writing new files.


### PR DESCRIPTION
- The OpenCode tandem agent fully owns its system prompt, so it lost the harness identity line the other harnesses get from their base prompts - it started cold with collaboration rules
- Adds the standard one-liner ("You are an expert assistant operating inside an agent harness...") as src/opencode/prompt-prefix.md; pi and claude are untouched (missing prefix files render empty for them)