### PR TITLE
Forward worker env to the tmux pane

### DIFF
--- a/packages/claude-tandem/runtime/spawn-tmux.sh
+++ b/packages/claude-tandem/runtime/spawn-tmux.sh
@@ -47,10 +47,17 @@ prompt=${prompt//\'/\'\\\'\'}
 
 # a crashed run may have left a stale result for this name
 rm -f "$result"
+
+# tmux gives the new pane the server's env, not the caller's - forward ours
+envargs=()
+while IFS= read -r -d '' kv; do
+  envargs+=(-e "$kv")
+done < <(env -0)
+
 if [[ -n "$model" ]]; then
-  tmux new-window -c "$PWD" -n "$name" "claude --model $model '$prompt'"
+  tmux new-window "${envargs[@]}" -c "$PWD" -n "$name" "claude --model $model '$prompt'"
 else
-  tmux new-window -c "$PWD" -n "$name" "claude '$prompt'"
+  tmux new-window "${envargs[@]}" -c "$PWD" -n "$name" "claude '$prompt'"
 fi
 tmux set-option -w -t "$name" automatic-rename off
 

--- a/packages/opencode-tandem/runtime/spawn-tmux.sh
+++ b/packages/opencode-tandem/runtime/spawn-tmux.sh
@@ -47,10 +47,17 @@ prompt=${prompt//\'/\'\\\'\'}
 
 # a crashed run may have left a stale result for this name
 rm -f "$result"
+
+# tmux gives the new pane the server's env, not the caller's - forward ours
+envargs=()
+while IFS= read -r -d '' kv; do
+  envargs+=(-e "$kv")
+done < <(env -0)
+
 if [[ -n "$model" ]]; then
-  tmux new-window -c "$PWD" -n "$name" "opencode --agent tandem --model $model --prompt '$prompt'"
+  tmux new-window "${envargs[@]}" -c "$PWD" -n "$name" "opencode --agent tandem --model $model --prompt '$prompt'"
 else
-  tmux new-window -c "$PWD" -n "$name" "opencode --agent tandem --prompt '$prompt'"
+  tmux new-window "${envargs[@]}" -c "$PWD" -n "$name" "opencode --agent tandem --prompt '$prompt'"
 fi
 tmux set-option -w -t "$name" automatic-rename off
 

--- a/packages/pi-tandem/runtime/spawn-tmux.sh
+++ b/packages/pi-tandem/runtime/spawn-tmux.sh
@@ -47,10 +47,17 @@ prompt=${prompt//\'/\'\\\'\'}
 
 # a crashed run may have left a stale result for this name
 rm -f "$result"
+
+# tmux gives the new pane the server's env, not the caller's - forward ours
+envargs=()
+while IFS= read -r -d '' kv; do
+  envargs+=(-e "$kv")
+done < <(env -0)
+
 if [[ -n "$model" ]]; then
-  tmux new-window -c "$PWD" -n "$name" "pi --no-session --model $model '$prompt'"
+  tmux new-window "${envargs[@]}" -c "$PWD" -n "$name" "pi --no-session --model $model '$prompt'"
 else
-  tmux new-window -c "$PWD" -n "$name" "pi --no-session '$prompt'"
+  tmux new-window "${envargs[@]}" -c "$PWD" -n "$name" "pi --no-session '$prompt'"
 fi
 tmux set-option -w -t "$name" automatic-rename off
 

--- a/src/runtime/spawn-tmux.sh
+++ b/src/runtime/spawn-tmux.sh
@@ -47,10 +47,17 @@ prompt=${prompt//\'/\'\\\'\'}
 
 # a crashed run may have left a stale result for this name
 rm -f "$result"
+
+# tmux gives the new pane the server's env, not the caller's - forward ours
+envargs=()
+while IFS= read -r -d '' kv; do
+  envargs+=(-e "$kv")
+done < <(env -0)
+
 if [[ -n "$model" ]]; then
-  tmux new-window -c "$PWD" -n "$name" "{{worker_cmd_model}}"
+  tmux new-window "${envargs[@]}" -c "$PWD" -n "$name" "{{worker_cmd_model}}"
 else
-  tmux new-window -c "$PWD" -n "$name" "{{worker_cmd}}"
+  tmux new-window "${envargs[@]}" -c "$PWD" -n "$name" "{{worker_cmd}}"
 fi
 tmux set-option -w -t "$name" automatic-rename off
 


### PR DESCRIPTION
- Workers spawned via spawn-tmux.sh now get the parent session's full live environment. The tmux pane previously received only the server's env (captured when the server started), so variables exported in the interactive shell - provider keys like NEURALWATT_API_KEY, PI_PROVIDER - never reached the worker and pi exited immediately with no provider configured
- Env is forwarded with `tmux new-window -e` per variable (tmux >= 3.2); the paseo spawn path is unaffected, it already inherits as a direct child
- One shared fix in `src/runtime/spawn-tmux.sh`, rendered into all three harness packages