### PR TITLE
Rewrite README intro and What's inside

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tandem skills
 
-Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that turn your agent harness from an autonomous code generator into a navigator: you drive, it advises and types, and nothing lands without you seeing it.
+Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that push back on agentic autonomy and give you control back: fewer unprompted antics, more actual collaboration.
 
 ## Install
 
@@ -25,20 +25,23 @@ pi install npm:pi-tandem
 
 ## Philosophy
 
-Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it did, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
+Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it saved, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
 
 ## What's inside
 
-- **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
-- **Skills**, loaded on demand:
-  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
+- **Pair-work prompt patch** - nudges the agent toward:
+  - fewer unprompted changes and unwelcome judgment calls
+  - more check-ins with you as it goes, so you can follow along and steer early
+  - toned-down nauseating sycophancy and "load bearing"-style LLMisms
+- **Skills**, each just a short file, loaded on demand:
+  - **Research** - verifies claims one at a time, with your go-ahead per step - a red herring or wrong conclusion gets caught while still cheap
   - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
-  - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
-  - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
-  - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
+  - **Coding** - "lazy senior" discipline: no speculative abstractions, deletion over addition, root-cause fixes, self-explanatory code over comment-peppering
+  - **Review** - carefully reads whatever you hand it, like docs or code, checks with you on debatable stuff, and then reports actionable findings with a fix each
+  - **Pull requests** - matches tone and length of the repo's recently merged PRs, proposes drafts before actually raising or updating a PR
+  - **Learn language** - kicks in only if you state that you are learning a language; background practice that stays out of the way of the work
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
-- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...) - added only for tools actually installed, so nothing about a missing tool ever ends up in the prompt
 
 ## Interactive subagents
 

--- a/packages/claude-tandem/README.md
+++ b/packages/claude-tandem/README.md
@@ -1,6 +1,6 @@
 # Tandem skills
 
-Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that turn your agent harness from an autonomous code generator into a navigator: you drive, it advises and types, and nothing lands without you seeing it.
+Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that push back on agentic autonomy and give you control back: fewer unprompted antics, more actual collaboration.
 
 ## Install
 
@@ -11,20 +11,23 @@ claude plugin install tandem@tandem-skills
 
 ## Philosophy
 
-Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it did, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
+Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it saved, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
 
 ## What's inside
 
-- **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
-- **Skills**, loaded on demand:
-  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
+- **Pair-work prompt patch** - nudges the agent toward:
+  - fewer unprompted changes and unwelcome judgment calls
+  - more check-ins with you as it goes, so you can follow along and steer early
+  - toned-down nauseating sycophancy and "load bearing"-style LLMisms
+- **Skills**, each just a short file, loaded on demand:
+  - **Research** - verifies claims one at a time, with your go-ahead per step - a red herring or wrong conclusion gets caught while still cheap
   - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
-  - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
-  - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
-  - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
+  - **Coding** - "lazy senior" discipline: no speculative abstractions, deletion over addition, root-cause fixes, self-explanatory code over comment-peppering
+  - **Review** - carefully reads whatever you hand it, like docs or code, checks with you on debatable stuff, and then reports actionable findings with a fix each
+  - **Pull requests** - matches tone and length of the repo's recently merged PRs, proposes drafts before actually raising or updating a PR
+  - **Learn language** - kicks in only if you state that you are learning a language; background practice that stays out of the way of the work
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
-- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...) - added only for tools actually installed, so nothing about a missing tool ever ends up in the prompt
 
 ## Interactive subagents
 

--- a/packages/opencode-tandem/README.md
+++ b/packages/opencode-tandem/README.md
@@ -1,6 +1,6 @@
 # Tandem skills
 
-Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that turn your agent harness from an autonomous code generator into a navigator: you drive, it advises and types, and nothing lands without you seeing it.
+Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that push back on agentic autonomy and give you control back: fewer unprompted antics, more actual collaboration.
 
 ## Install
 
@@ -10,20 +10,23 @@ opencode plugin -g opencode-tandem
 
 ## Philosophy
 
-Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it did, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
+Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it saved, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
 
 ## What's inside
 
-- **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
-- **Skills**, loaded on demand:
-  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
+- **Pair-work prompt patch** - nudges the agent toward:
+  - fewer unprompted changes and unwelcome judgment calls
+  - more check-ins with you as it goes, so you can follow along and steer early
+  - toned-down nauseating sycophancy and "load bearing"-style LLMisms
+- **Skills**, each just a short file, loaded on demand:
+  - **Research** - verifies claims one at a time, with your go-ahead per step - a red herring or wrong conclusion gets caught while still cheap
   - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
-  - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
-  - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
-  - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
+  - **Coding** - "lazy senior" discipline: no speculative abstractions, deletion over addition, root-cause fixes, self-explanatory code over comment-peppering
+  - **Review** - carefully reads whatever you hand it, like docs or code, checks with you on debatable stuff, and then reports actionable findings with a fix each
+  - **Pull requests** - matches tone and length of the repo's recently merged PRs, proposes drafts before actually raising or updating a PR
+  - **Learn language** - kicks in only if you state that you are learning a language; background practice that stays out of the way of the work
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
-- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...) - added only for tools actually installed, so nothing about a missing tool ever ends up in the prompt
 
 ## Interactive subagents
 

--- a/packages/opencode-tandem/package.json
+++ b/packages/opencode-tandem/package.json
@@ -2,6 +2,11 @@
   "name": "opencode-tandem",
   "version": "0.5.3",
   "description": "Shared agent system prompt and skills for OpenCode, from the tandem-skills repo",
+  "keywords": [
+    "opencode",
+    "tandem-skills",
+    "skills"
+  ],
   "type": "module",
   "license": "MIT",
   "files": [

--- a/packages/pi-tandem/README.md
+++ b/packages/pi-tandem/README.md
@@ -1,6 +1,6 @@
 # Tandem skills
 
-Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that turn your agent harness from an autonomous code generator into a navigator: you drive, it advises and types, and nothing lands without you seeing it.
+Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that push back on agentic autonomy and give you control back: fewer unprompted antics, more actual collaboration.
 
 ## Install
 
@@ -10,20 +10,23 @@ pi install npm:pi-tandem
 
 ## Philosophy
 
-Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it did, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
+Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it saved, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
 
 ## What's inside
 
-- **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
-- **Skills**, loaded on demand:
-  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
+- **Pair-work prompt patch** - nudges the agent toward:
+  - fewer unprompted changes and unwelcome judgment calls
+  - more check-ins with you as it goes, so you can follow along and steer early
+  - toned-down nauseating sycophancy and "load bearing"-style LLMisms
+- **Skills**, each just a short file, loaded on demand:
+  - **Research** - verifies claims one at a time, with your go-ahead per step - a red herring or wrong conclusion gets caught while still cheap
   - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
-  - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
-  - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
-  - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
+  - **Coding** - "lazy senior" discipline: no speculative abstractions, deletion over addition, root-cause fixes, self-explanatory code over comment-peppering
+  - **Review** - carefully reads whatever you hand it, like docs or code, checks with you on debatable stuff, and then reports actionable findings with a fix each
+  - **Pull requests** - matches tone and length of the repo's recently merged PRs, proposes drafts before actually raising or updating a PR
+  - **Learn language** - kicks in only if you state that you are learning a language; background practice that stays out of the way of the work
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
-- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...) - added only for tools actually installed, so nothing about a missing tool ever ends up in the prompt
 
 ## Interactive subagents
 

--- a/packages/pi-tandem/package.json
+++ b/packages/pi-tandem/package.json
@@ -7,7 +7,9 @@
   },
   "description": "Shared agent system prompt and skills for pi, from the tandem-skills repo",
   "keywords": [
-    "pi-package"
+    "pi-package",
+    "tandem-skills",
+    "skills"
   ],
   "type": "module",
   "license": "MIT",

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # Tandem skills
 
-Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that turn your agent harness from an autonomous code generator into a navigator: you drive, it advises and types, and nothing lands without you seeing it.
+Pair-programming rules for coding agents. A system-prompt patch plus a small set of skills that push back on agentic autonomy and give you control back: fewer unprompted antics, more actual collaboration.
 
 ## Install
 
@@ -8,20 +8,23 @@ Pair-programming rules for coding agents. A system-prompt patch plus a small set
 
 ## Philosophy
 
-Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it did, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
+Modern coding agents lean toward autonomy: multi-file changes in one go, subagent fan-out, reinforced by the system prompts of popular harnesses (especially Claude Code). The usual result is a bloated clump of code that hopefully works - and reviewing it costs more than generating it saved, since you still have to read all of it. Tandem inverts this: keep changes small enough that each step is cheap to review, and prune misalignment early, before it compounds into slop. The result is both faster and higher-quality.
 
 ## What's inside
 
-- **Pair-work prompt patch** - collaboration style (lock-step, explicit go-aheads) and terse communication rules
-- **Skills**, loaded on demand:
-  - **Research** - pairs with you digging through data, documents and code to get a verified answer to a question
+- **Pair-work prompt patch** - nudges the agent toward:
+  - fewer unprompted changes and unwelcome judgment calls
+  - more check-ins with you as it goes, so you can follow along and steer early
+  - toned-down nauseating sycophancy and "load bearing"-style LLMisms
+- **Skills**, each just a short file, loaded on demand:
+  - **Research** - verifies claims one at a time, with your go-ahead per step - a red herring or wrong conclusion gets caught while still cheap
   - **Brainstorm** - interviews you about the idea one question at a time, or rubber ducks while you think out loud, until you and the model get on the same page
-  - **Coding** - "lazy senior" discipline for code changes: no speculative abstractions, deletion over addition, root-cause fixes
-  - **Review** - interactively checks code and documents for errors and bloat, actionable findings only
-  - **Pull requests** - branch, title and description rules, calibrated to the repo's merged PRs
-  - **Learn language** - optional practice of a foreign language as you work, suitable for every level, even beginners
+  - **Coding** - "lazy senior" discipline: no speculative abstractions, deletion over addition, root-cause fixes, self-explanatory code over comment-peppering
+  - **Review** - carefully reads whatever you hand it, like docs or code, checks with you on debatable stuff, and then reports actionable findings with a fix each
+  - **Pull requests** - matches tone and length of the repo's recently merged PRs, proposes drafts before actually raising or updating a PR
+  - **Learn language** - kicks in only if you state that you are learning a language; background practice that stays out of the way of the work
 - **Interactive subagents** - fresh-context workers you can steer and must approve; details in the [Interactive subagents](#interactive-subagents) section
-- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...), added to the prompt only if the tool is actually installed
+- **Tool-specific instructions** (`gh`, `aws`, `jira`, ...) - added only for tools actually installed, so nothing about a missing tool ever ends up in the prompt
 
 ## Interactive subagents
 


### PR DESCRIPTION
- Intro pitch rewritten: drops the navigator metaphor ("you drive, it advises and types") for "push back on agentic autonomy and give you control back: fewer unprompted antics, more actual collaboration"
- What's inside rewritten bullet by bullet, hedged the way the prompt actually behaves - nudges, not bans - including the pair-work patch as three separate bullets (fewer unprompted changes and unwelcome judgment calls, more check-ins to follow and steer early, toned-down sycophancy and "load bearing"-style LLMisms)
- Research item matches the interactive claim-by-claim loop from #18; Review and Pull requests items reworded to match the current skills
- npm keywords added: `pi-package`, `tandem-skills`, `skills` on pi-tandem; `opencode`, `tandem-skills`, `skills` on opencode-tandem